### PR TITLE
Fixes Issue 1067 (#1069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ## Unreleased - 2020-??-??
 
+### Fixed
+
+* Latest 4.0.0 Eclipse plugin is not functional ([#1067](https://github.com/spotbugs/spotbugs/issues/1067))
+
 ## 4.0.0-RC1 - 2020-01-17
 
 ### Changed

--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -93,10 +93,21 @@ javadoc {
 }
 
 task copyLibsForEclipse(type: Copy) {
-    dependsOn configurations.compile
-    from configurations.compile.files {
+    dependsOn project(':spotbugs').configurations.runtimeClasspath
+    from ('../spotbugs/.libs') {
       include "*.jar"
       exclude "*xml-apis*.jar"
+      exclude "*ant-*.jar"
+      exclude "Apple*.jar"
+      exclude "hamcrest*.jar"
+      exclude "slf4j-*alpha*.jar"
+      exclude "Saxon*.jar"
+    }
+    from ('../spotbugs/build/libs') {
+      include "*.jar"
+    }
+    from ('../spotbugs-annotations/build/libs') {
+      include "*.jar"
     }
     into "lib"
 }

--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -107,7 +107,7 @@ tasks.withType(Jar).all {
 eclipse.classpath {
   plusConfigurations += [ configurations.compileOnly ]
   plusConfigurations += [ configurations.guiCompileOnly ]
-  plusConfigurations += [ configurations.testImplementation ]
+  plusConfigurations += [ configurations.testRuntimeClasspath ]
 }
 
 eclipse.classpath.file {
@@ -126,7 +126,7 @@ eclipse.classpath.file {
 }
 
 task copyLibsForEclipse (type: Copy) {
-    from configurations.compileClasspath.files
+    from configurations.runtimeClasspath.files
     into ".libs"
     include "*.jar"
     exclude "*xml-apis*.jar"
@@ -136,7 +136,7 @@ task copyLibsForEclipse (type: Copy) {
     into ".libs"
     include "*.jar"
 
-    from configurations.testCompileClasspath.files
+    from configurations.testRuntimeClasspath.files
     into ".libs"
     include "*.jar"
 
@@ -150,7 +150,7 @@ task copyLibsForEclipse (type: Copy) {
 }
 
 task updateManifest {
-  dependsOn configurations.compileClasspath, copyLibsForEclipse
+  dependsOn configurations.runtimeClasspath, copyLibsForEclipse
   doLast {
     def manifestSpec = manifest {
       from "$projectDir/META-INF/MANIFEST-TEMPLATE.MF"
@@ -251,7 +251,7 @@ distributions {
          include 'README'
       }
       from 'licenses'
-      from([configurations.compileClasspath, configurations.logBinding]) {
+      from([configurations.runtimeClasspath, configurations.logBinding]) {
         into 'lib'
         include '**/*.jar'
       }


### PR DESCRIPTION
* fix: use testCompileClasspath to resolve libraries

close #1067

* fix: copy libraries required by spotbugs to Eclipse plugin lib folder

fixes issue #1067

* build: when copy libs, refer runtimeClasspath instead of compileClasspath

* docs: add an entry to CHANGELOG

Co-authored-by: Kengo TODA <skypencil+github@gmail.com>



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
