### PR TITLE
Fix UnsupportedOperationException in BugRanker.trimToMaxRank (#1436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 
 ### Fixed
 * `UWF_NULL_FIELD` doesn't report line number ([#1368](https://github.com/spotbugs/spotbugs/issues/1368))
+* UnsupportedOperationException in BugRanker.trimToMaxRank ([#1161](https://github.com/spotbugs/spotbugs/issues/1161))
 
 ### Changed
 * Bump ASM from 9.0 to 9.1 supporting JDK17

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/BugRanker.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/BugRanker.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.annotation.CheckForNull;
@@ -319,6 +320,12 @@ public class BugRanker {
     }
 
     public static void trimToMaxRank(BugCollection origCollection, int maxRank) {
-        origCollection.getCollection().removeIf(b -> BugRanker.findRank(b) > maxRank);
+        // Avoid SortedBugCollection.getCollection() because it is immutable.
+        for (Iterator<BugInstance> i = origCollection.iterator(); i.hasNext();) {
+            BugInstance b = i.next();
+            if (BugRanker.findRank(b) > maxRank) {
+                i.remove();
+            }
+        }
     }
 }

--- a/spotbugs/src/test/java/edu/umd/cs/findbugs/BugRankerTest.java
+++ b/spotbugs/src/test/java/edu/umd/cs/findbugs/BugRankerTest.java
@@ -1,0 +1,19 @@
+package edu.umd.cs.findbugs;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class BugRankerTest {
+    /**
+     * @see <a href="https://github.com/spotbugs/spotbugs/issues/1161">GitHub issue</a>
+     */
+    @Test
+    public void testTrimToMaxRank() {
+        SortedBugCollection bugCollection = new SortedBugCollection();
+        bugCollection.add(new BugInstance("type", Priorities.HIGH_PRIORITY).addClass("the/target/Class"));
+        BugRanker.trimToMaxRank(bugCollection, 0);
+
+        assertTrue(bugCollection.getCollection().isEmpty());
+    }
+}


### PR DESCRIPTION
* Fix BugRanker.trimToMaxRank

* Update change log

* Ran ./gradlew :spotbugs:spotlessApply to fix code format

* Add link text



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
